### PR TITLE
Changed Twig function class to a non-abstract one

### DIFF
--- a/lib/Timber/Integrations/WooCommerce/WooCommerce.php
+++ b/lib/Timber/Integrations/WooCommerce/WooCommerce.php
@@ -320,7 +320,7 @@ class WooCommerce {
 	 * @return mixed
 	 */
 	public function add_timber_functions( $twig ) {
-		$twig->addFunction( new \Twig_Function( 'Product', function( $pid ) {
+		$twig->addFunction( new \Twig_SimpleFunction( 'Product', function( $pid ) {
 			return new self::$product_class( $pid );
 		} ) );
 


### PR DESCRIPTION
Need to make use of the Twig_SimpleFunction which extends of Twig_Function as you can't instantiate an abstract class.