### PR TITLE
Make better use of Post Class Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0
 
+- Improved internal handling for loading the internal `Product` class.
 - Improved default **archive-product.twig** template and added default templates for **loop/loop-start.twig** and **loop/loop-end.twig**.
 - Added a `$context` parameter to the `render_default_template()` function.
 


### PR DESCRIPTION
Until now, when the condition `is_woocommerce()` was true, the `Timber\Integration\WooCommerce\Product` was applied for all posts. With this pull request, we would only apply it to posts that have the post type `product`.

Instead of instantiating the `Product` class directly, we use `Timber::get_post()`, which uses the Post Class Map in the background. This way, if you already work with extended posts, you can keep them. And this also makes it possible to extend the `Product` class.