### PR TITLE
Add the #[\ReturnTypeWillChange] attribute so that plugin would have …

### DIFF
--- a/lib/ProductsIterator.php
+++ b/lib/ProductsIterator.php
@@ -58,6 +58,7 @@ class ProductsIterator extends \Timber\PostsIterator {
 	 *
 	 * @since 2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function next() {
 		/**
 		 * The `loop_end` action is not the only thing we do to improve compatibility. There’s


### PR DESCRIPTION
…backwards compatibility but would not show deprecated error with PHP 8.1.

I updated my local development to DDEV (using NGINX) and with PHP 8.1 i got following error message:
`Deprecated: Return type of Timber\Integrations\WooCommerce\ProductsIterator::next() should either be compatible with ArrayIterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/cms/wp-content/themes/velohunt/vendor/mindkomm/timber-integration-woocommerce/lib/ProductsIterator.php on line 61`

My proposal is to add #[\ReturnTypeWillChange] tag so that we would have backwards compatibility for older PHP. It looks like comment for older PHP versions and tells PHP 8.1 not to raise the deprecation notice.

I think it's pretty safe way to go for now based on: [https://php.watch/versions/8.1/ReturnTypeWillChange](https://php.watch/versions/8.1/ReturnTypeWillChange)