### PR TITLE
feat: Deprecate theme/woocommerce/views_folder filter in favor of timber/woocommerce/views_folder

### DIFF
--- a/lib/WooCommerce.php
+++ b/lib/WooCommerce.php
@@ -36,12 +36,19 @@ class WooCommerce {
 	public static function init() {
 		$self = new self();
 
+		self::$subfolder = apply_filters_deprecated(
+			'theme/woocommerce/views_folder',
+			['woocommerce'],
+			'1.1.0',
+			'timber/woocommerce/views_folder'
+		);
+
 		/**
 		 * Filters the subfolder to use in the Twig template file folder.
 		 *
 		 * @param string $subfolder Subfolder name.
 		 */
-		self::$subfolder = apply_filters( 'theme/woocommerce/views_folder', 'woocommerce' );
+		self::$subfolder = apply_filters( 'timber/woocommerce/views_folder', 'woocommerce' );
 		self::$subfolder = trailingslashit( self::$subfolder );
 
 		add_filter( 'wc_get_template', array( $self, 'maybe_render_twig_template' ), 10, 3 );


### PR DESCRIPTION
In 1.x, a new `theme/woocommerce/views_folder` filter was added. This filter uses the wrong prefix `theme/woocommerce` instead of `timber/woocommerce`, like all other hooks of this package.

To fix this, this pull request deprecates the `theme/woocommerce/views_folder` using `apply_filters_deprecated()` and adds the new correct filter `timber/woocommerce/views_folder`. 

The old filter will still work until the next major version, but you are encouraged to use the new `timber/woocommerce/views_folder` filter.