### PR TITLE
feat!: Remove `woocommerce_shop_loop` hook call in `Product::setup()` to reduce side effects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 1.x
+      - 2.x
 
 permissions:
   contents: write

--- a/defaults/archive-product.twig
+++ b/defaults/archive-product.twig
@@ -32,7 +32,7 @@
 
     {% if fn('woocommerce_product_loop') %}
         {#
-         # woocommerce_before_shop_loop hook.
+         # Hook: woocommerce_before_shop_loop.
          #
          # @hooked woocommerce_output_all_notices - 10
          # @hooked woocommerce_result_count - 20
@@ -50,6 +50,11 @@
 	             # calling `have_posts()`, we check if there are posts we can display.
 	             #}
 	            {% if fn('have_posts') %}
+                    {##
+                     # Hook: woocommerce_shop_loop.
+                     #}
+                    {% do action('woocommerce_shop_loop') %}
+
                     {{ fn('wc_get_template_part', 'content', 'product' ) }}
 	            {% endif %}
             {% endfor %}

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -64,16 +64,6 @@ class Product extends Post {
 		return $post;
 	}
 
-	public function setup() {
-		parent::setup();
-
-		if ( ! is_singular( 'product' ) && did_action( 'woocommerce_before_shop_loop' ) > 0 ) {
-			do_action( 'woocommerce_shop_loop' );
-		}
-
-		return $this;
-	}
-
 	/**
 	 * Get the first assigned product category.
 	 *


### PR DESCRIPTION
WooCommerce calls the `woocommerce_shop_loop` hook inside the product posts loop in the product archive.

**archive-product.php**

```php
if ( wc_get_loop_prop( 'total' ) ) {
	while ( have_posts() ) {
		the_post();

		/**
		 * Hook: woocommerce_shop_loop.
		 */
		do_action( 'woocommerce_shop_loop' );

		wc_get_template_part( 'content', 'product' );
	}
}
```

This integration tried to optimize this by calling the `woocommerce_shop_loop` hook in `Product::setup()`. But, in themes where **archive-product.php** is not overwritten with a custom template, the hook might already be called. We didn’t have a check for that in `Product::setup()` and it’s also hard to check for this.

The best fix for this is to remove the check in `Product::setup()` and manually add the `woocommerce_shop_loop` hook call in **archive-product.twig**.

**🚫 Before**

```twig
{% if fn('wc_get_loop_prop', 'total') %}
	{% for post in posts %}
		{##
		 # Depending on your WooCommerce display settings, the
		 # `woocommerce_product_subcategories` function might reset the $wp_query global. By
		 # calling `have_posts()`, we check if there are posts we can display.
		 #}
		{% if fn('have_posts') %}
			{{ fn('wc_get_template_part', 'content', 'product' ) }}
		{% endif %}
	{% endfor %}
{% endif %}
```

**✅ After**

```twig
{% if fn('wc_get_loop_prop', 'total') %}
	{% for post in posts %}
		{##
		 # Depending on your WooCommerce display settings, the
		 # `woocommerce_product_subcategories` function might reset the $wp_query global. By
		 # calling `have_posts()`, we check if there are posts we can display.
		 #}
		{% if fn('have_posts') %}
			{##
			 # Hook: woocommerce_shop_loop.
			 #}
			{% do action('woocommerce_shop_loop') %}
			
			{{ fn('wc_get_template_part', 'content', 'product' ) }}
		{% endif %}
	{% endfor %}
{% endif %}
```

This way, we stop trying to be smart about things and make the whole package more predictable.

Because this is potentially a breaking change for anyone relying on the `woocommerce_shop_loop` hook, this change will require a new major version.