### PR TITLE
feat!: Deprecate timber/integration/woocommerce/product filter in favor of timber/woocommerce/product

### DIFF
--- a/lib/Product.php
+++ b/lib/Product.php
@@ -54,10 +54,22 @@ class Product extends Post {
 			$product = wc_get_product( $post->ID );
 		}
 
+		$product = apply_filters_deprecated(
+			'timber/integration/woocommerce/product',
+			[ $product, $post ],
+			'1.1.0',
+			'timber/woocommerce/product'
+		);
+
 		/**
-		 * Filters the WooCommerce product
+		 * Filters the WooCommerce product.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param \WC_Product $product The WooCommerce product.
+		 * @param \WP_Post    $post    The WordPress post.
 		 */
-		$product = apply_filters( 'timber/integration/woocommerce/product', $product, $post );
+		$product = apply_filters( 'timber/woocommerce/product', $product, $post );
 
 		$post->product = $product;
 


### PR DESCRIPTION
The `timber/integration/woocommerce/product` filter is the only hook that doesn’t use the `timber/woocommerce` filter prefix.

To streamline all hook names, we deprecate the `timber/integration/woocommerce/product` filter in favor of `timber/woocommerce/product`.

The `timber/integration/woocommerce/product` hook will work fine until the next major version of the package, but will be removed then.